### PR TITLE
SAM-73564: Subscribe to Order Created workflow event (SDK 2.0.12)

### DIFF
--- a/vim-canvas-demo-app-react/package-lock.json
+++ b/vim-canvas-demo-app-react/package-lock.json
@@ -37,7 +37,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vim-app-settings": "^1.0.0",
-        "vim-os-js-browser": "^2.0.10"
+        "vim-os-js-browser": "^2.0.12"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.1",
@@ -6145,9 +6145,9 @@
       "integrity": "sha512-xUv5Bs7im1WUf0erwyWP+PuPjfFAMLc9SNnqPAX00j1TZG88+t19suxTzMiQyQppPYeCJpyOO4qPRb0QkzM/Tg=="
     },
     "node_modules/vim-os-js-browser": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/vim-os-js-browser/-/vim-os-js-browser-2.0.10.tgz",
-      "integrity": "sha512-CR8i0kRny3Tm+ukO6dUe6dlnpIUUGsOyORdxa7tAfsEZaYMXd02Z+Ph77ZdAZC2X1an49g1kE9ypLr1B0viAng==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/vim-os-js-browser/-/vim-os-js-browser-2.0.12.tgz",
+      "integrity": "sha512-v9ASuT/vWVw24Xoapl0easpmG7JNYFSKNjA7bklRHt+b2unSBVNyvylCGJnMltAZdceZblgMlkKOjLJ3vwBnLw==",
       "dependencies": {
         "zod": "^3.23.8"
       }

--- a/vim-canvas-demo-app-react/package-lock.json
+++ b/vim-canvas-demo-app-react/package-lock.json
@@ -90,14 +90,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -214,18 +214,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -241,25 +241,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -299,26 +299,23 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -352,13 +349,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -384,10 +381,25 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250214.0.tgz",
-      "integrity": "sha512-cDvvedWDc5zrgDnuXe2qYcz/TwBvzmweO55C7XpPuAWJ9Oqxv81PkdekYxD8mH989aQ/GI5YD0Fe6fDYlM+T3Q==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
       "cpu": [
         "x64"
       ],
@@ -401,9 +413,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250214.0.tgz",
-      "integrity": "sha512-NytCvRveVzu0mRKo+tvZo3d/gCUway3B2ZVqSi/TS6NXDGBYIJo7g6s3BnTLS74kgyzeDOjhu9j/RBJBS809qw==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
       "cpu": [
         "arm64"
       ],
@@ -417,9 +429,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250214.0.tgz",
-      "integrity": "sha512-pQ7+aHNHj8SiYEs4d/6cNoimE5xGeCMfgU1yfDFtA9YGN9Aj2BITZgOWPec+HW7ZkOy9oWlNrO6EvVjGgB4tbQ==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
       "cpu": [
         "x64"
       ],
@@ -433,9 +445,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250214.0.tgz",
-      "integrity": "sha512-Vhlfah6Yd9ny1npNQjNgElLIjR6OFdEbuR3LCfbLDCwzWEBFhIf7yC+Tpp/a0Hq7kLz3sLdktaP7xl3PJhyOjA==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
       "cpu": [
         "arm64"
       ],
@@ -449,9 +461,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250214.0.tgz",
-      "integrity": "sha512-GMwMyFbkjBKjYJoKDhGX8nuL4Gqe3IbVnVWf2Q6086CValyIknupk5J6uQWGw2EBU3RGO3x4trDXT5WphQJZDQ==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
       "cpu": [
         "x64"
       ],
@@ -465,9 +477,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250303.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250303.0.tgz",
-      "integrity": "sha512-O7F7nRT4bbmwHf3gkRBLfJ7R6vHIJ/oZzWdby6obOiw2yavUfp/AIwS7aO2POu5Cv8+h3TXS3oHs3kKCZLraUA==",
+      "version": "4.20250906.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250906.0.tgz",
+      "integrity": "sha512-CMRTupQpAdNZJrxRGaM2JzxmpWOnzgxcyTGmjAOcosRfi1ZsNUTAZ0kj1dzY+4bPDIdFwvvJL3t91DEpqitOJg==",
       "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -893,9 +905,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
       "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -932,9 +944,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
@@ -945,10 +957,19 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -958,9 +979,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
-      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -993,12 +1014,15 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
-      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1011,12 +1035,12 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -2726,11 +2750,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2946,9 +2965,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3055,9 +3074,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3233,9 +3252,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3573,12 +3592,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3782,18 +3795,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
-      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
-        "@eslint/core": "^0.12.0",
-        "@eslint/eslintrc": "^3.3.0",
-        "@eslint/js": "9.21.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.35.0",
+        "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3804,9 +3818,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3862,9 +3876,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -3878,9 +3892,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3890,14 +3904,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3965,6 +3979,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4198,9 +4218,9 @@
       "dev": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4608,9 +4628,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20250214.2",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250214.2.tgz",
-      "integrity": "sha512-t+lT4p2lbOcKv4PS3sx1F/wcDAlbEYZCO2VooLp4H7JErWWYIi9yjD3UillC3CGOpiBahVg5nrPCoFltZf6UlA==",
+      "version": "3.20250718.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.1.tgz",
+      "integrity": "sha512-9QAOHVKIVHmnQ1dJT9Fls8aVA8R5JjEizzV889Dinq/+bEPltqIepCvm9Z+fbNUgLvV7D/H1NUk8VdlLRgp9Wg==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -4620,9 +4640,9 @@
         "glob-to-regexp": "0.4.1",
         "stoppable": "1.1.0",
         "undici": "^5.28.5",
-        "workerd": "1.20250214.0",
+        "workerd": "1.20250718.0",
         "ws": "8.18.0",
-        "youch": "3.2.3",
+        "youch": "3.3.4",
         "zod": "3.22.3"
       },
       "bin": {
@@ -4630,6 +4650,18 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/miniflare/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/miniflare/node_modules/zod": {
@@ -4660,24 +4692,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4767,9 +4781,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.5.tgz",
-      "integrity": "sha512-AtXrG/lMFjPBWj3uhWYFwYVZQqutPYRsv6nnPLTipnC+gJuMFc+WFzf/jx+94Ebray1vxfQfEFDtpIpppOe4xQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true
     },
     "node_modules/optionator": {
@@ -4885,9 +4899,9 @@
       "dev": true
     },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
     "node_modules/picocolors": {
@@ -4921,23 +4935,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.5.3",
@@ -5269,14 +5266,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.2.0.tgz",
-      "integrity": "sha512-fXyqzPgCPZbqhrk7k3hPcCpYIlQ2ugIXDboHUzhJISFVy2DEPsmHgN588MyGmkIOv3jDgNfUE3kJi83L28s/LQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
       "dependencies": {
-        "@types/cookie": "^0.6.0",
         "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5292,11 +5287,11 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.2.0.tgz",
-      "integrity": "sha512-cU7lTxETGtQRQbafJubvZKHEn5izNABxZhBY0Jlzdv0gqQhCPQt2J8aN5ZPjS6mQOXn5NnirWNh+FpE8TTYN0Q==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
       "dependencies": {
-        "react-router": "7.2.0"
+        "react-router": "7.8.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5353,12 +5348,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5965,11 +5954,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -6018,15 +6002,15 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -6042,15 +6026,15 @@
       "dev": true
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.1.tgz",
-      "integrity": "sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==",
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
       "dev": true,
       "dependencies": {
         "defu": "^6.1.4",
-        "mlly": "^1.7.4",
-        "ohash": "^1.1.4",
-        "pathe": "^1.1.2",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
         "ufo": "^1.5.4"
       }
     },
@@ -6153,9 +6137,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -6235,9 +6219,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250214.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250214.0.tgz",
-      "integrity": "sha512-QWcqXZLiMpV12wiaVnb3nLmfs/g4ZsFQq2mX85z546r3AX4CTIkXl0VP50W3CwqLADej3PGYiRDOTelDOwVG1g==",
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -6247,28 +6231,29 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250214.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250214.0",
-        "@cloudflare/workerd-linux-64": "1.20250214.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250214.0",
-        "@cloudflare/workerd-windows-64": "1.20250214.0"
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.112.0.tgz",
-      "integrity": "sha512-PNQWGze3ODlWwG33LPr8kNhbht3eB3L9fogv+fapk2fjaqj0kNweRapkwmvtz46ojcqWzsxmTe4nOC0hIVUfPA==",
+      "version": "3.114.14",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.14.tgz",
+      "integrity": "sha512-zytHJn5+S47sqgUHi71ieSSP44yj9mKsj0sTUCsY+Tw5zbH8EzB1d9JbRk2KHg7HFM1WpoTI7518EExPGenAmg==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
         "@esbuild-plugins/node-globals-polyfill": "0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "0.2.2",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.17.19",
-        "miniflare": "3.20250214.2",
+        "miniflare": "3.20250718.1",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.1",
-        "workerd": "1.20250214.0"
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -6282,7 +6267,7 @@
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250214.0"
+        "@cloudflare/workers-types": "^4.20250408.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -6888,20 +6873,20 @@
       }
     },
     "node_modules/youch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-      "integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
       "dev": true,
       "dependencies": {
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.1",
         "mustache": "^4.2.0",
         "stacktracey": "^2.1.8"
       }
     },
     "node_modules/youch/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"

--- a/vim-canvas-demo-app-react/package.json
+++ b/vim-canvas-demo-app-react/package.json
@@ -41,7 +41,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vim-app-settings": "^1.0.0",
-    "vim-os-js-browser": "^2.0.10"
+    "vim-os-js-browser": "^2.0.12"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240821.1",

--- a/vim-canvas-demo-app-react/src/App.tsx
+++ b/vim-canvas-demo-app-react/src/App.tsx
@@ -40,11 +40,11 @@ function App() {
   const { patient } = useVimOSPatient();
   const { encounter } = useVimOSEncounter();
   const { referral } = useVimOSReferral();
-  const { orders } = useVimOSOrders();
+  const { orders, orderCreatedEvents } = useVimOSOrders();
   const { claim } = useVimOSClaim();
   const [redirectUrl, setRedirectUrl] = useState<string | undefined>(undefined);
   const [redirectModalOpen, setRedirectModal] = useState(false);
-  const [themeColor, setThemeColor] = useState<string>("#00FFE1");
+  const [themeColor, setThemeColor] = useState<string>("#04B39F");
   const { idToken } = useIdToken();
 
   useEffect(() => {
@@ -142,7 +142,11 @@ function App() {
           </CollapsibleEntityContent>
         </CollapsibleEntity>
       )}
-      {orders && <OrdersWrapper orders={orders} themeColor={themeColor} />}
+      <OrdersWrapper
+        orders={orders}
+        orderCreatedEvents={orderCreatedEvents}
+        themeColor={themeColor}
+      />
       {claim && (
         <CollapsibleEntity
           entityTitle="Claim"

--- a/vim-canvas-demo-app-react/src/AppWrapper.tsx
+++ b/vim-canvas-demo-app-react/src/AppWrapper.tsx
@@ -31,7 +31,7 @@ export const AppWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
           <VimOSReferralProvider>
             <VimOSOrdersProvider>
               <VimOSClaimProvider>
-              <VimOSEncounterProvider>{children}</VimOSEncounterProvider>
+                <VimOSEncounterProvider>{children}</VimOSEncounterProvider>
               </VimOSClaimProvider>
             </VimOSOrdersProvider>
           </VimOSReferralProvider>

--- a/vim-canvas-demo-app-react/src/components/orders/OrdersWrapper.tsx
+++ b/vim-canvas-demo-app-react/src/components/orders/OrdersWrapper.tsx
@@ -33,6 +33,7 @@ export const OrdersWrapper: React.FC<{
     <>
       {orders?.map((order, index) => {
         const orderType = order.basicInformation?.type;
+        const orderKey = order.identifiers?.ehrOrderId ?? index;
         return (
           <CollapsibleEntity
             entityTitle={"Order"}
@@ -40,7 +41,7 @@ export const OrdersWrapper: React.FC<{
             entityIconUrl={(orderType && orderIcons[orderType]) ?? orderSvg}
             themeColor={themeColor}
             badge="State"
-            key={index}
+            key={orderKey}
           >
             <CollapsibleEntityContent>
               <OrderContent order={order} />
@@ -51,6 +52,7 @@ export const OrdersWrapper: React.FC<{
       {orderCreatedEvents.map((orderCreatedEvent, index) => {
         const { payload: order, receivedAt } = orderCreatedEvent;
         const orderType = order.basicInformation?.type;
+        const orderKey = order.identifiers?.ehrOrderId ?? index;
         return (
           <CollapsibleEntity
             entityTitle="Order created"
@@ -75,7 +77,7 @@ export const OrdersWrapper: React.FC<{
                 <Trash2 className="w-4 h-4" />
               </Button>
             }
-            key={index}
+            key={orderKey}
           >
             <CollapsibleEntityContent variant="dashed">
               <OrderContent order={order} />

--- a/vim-canvas-demo-app-react/src/components/orders/OrdersWrapper.tsx
+++ b/vim-canvas-demo-app-react/src/components/orders/OrdersWrapper.tsx
@@ -4,36 +4,80 @@ import orderProcedureSvg from "@/assets/order-procedure.svg";
 import orderRxSvg from "@/assets/order-rx.svg";
 import orderSvg from "@/assets/order.svg";
 import React from "react";
+import { Trash2 } from "lucide-react";
 import { EHR } from "vim-os-js-browser/types";
 import {
   CollapsibleEntity,
   CollapsibleEntityContent,
 } from "../ui/collapsibleEntity";
 import { OrderContent } from "./OrderContent";
+import type { WorkflowEvent } from "@/types/workflowEvent";
+import { formatContentDate } from "@/utils/formatContentDate";
+import { Button } from "../ui/button";
+import { capitalize } from "@/lib/utils";
 
 const orderIcons: Record<EHR.OrderType, string> = {
   DI: orderDiSvg,
   LAB: orderLabSvg,
   RX: orderRxSvg,
   PROCEDURE: orderProcedureSvg,
+  REFERRAL: orderSvg,
 };
 
 export const OrdersWrapper: React.FC<{
   orders: EHR.Order[];
+  orderCreatedEvents: WorkflowEvent<EHR.Order>[];
   themeColor?: string;
-}> = ({ orders, themeColor }) => {
+}> = ({ orders, orderCreatedEvents, themeColor }) => {
   return (
     <>
       {orders?.map((order, index) => {
         const orderType = order.basicInformation?.type;
         return (
           <CollapsibleEntity
-            entityTitle={orderType ? `Order - ${orderType}` : "Order"}
+            entityTitle={"Order"}
+            titleSuffix={orderType ? `- ${capitalize(orderType)}` : ""}
             entityIconUrl={(orderType && orderIcons[orderType]) ?? orderSvg}
             themeColor={themeColor}
+            badge="State"
             key={index}
           >
             <CollapsibleEntityContent>
+              <OrderContent order={order} />
+            </CollapsibleEntityContent>
+          </CollapsibleEntity>
+        );
+      })}
+      {orderCreatedEvents.map((orderCreatedEvent, index) => {
+        const { payload: order, receivedAt } = orderCreatedEvent;
+        const orderType = order.basicInformation?.type;
+        return (
+          <CollapsibleEntity
+            entityTitle="Order created"
+            titleSuffix={orderType ? `- ${capitalize(orderType)}` : ""}
+            subtitle={formatContentDate(receivedAt, {
+              format: "hh:mm:ss aa",
+            })}
+            entityIconUrl={(orderType && orderIcons[orderType]) ?? orderSvg}
+            themeColor={themeColor}
+            badge="Event"
+            variant="dashed"
+            rightAccessory={
+              <Button
+                variant="ghost"
+                className="p-1"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  orderCreatedEvent.dismiss();
+                }}
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            }
+            key={index}
+          >
+            <CollapsibleEntityContent variant="dashed">
               <OrderContent order={order} />
             </CollapsibleEntityContent>
           </CollapsibleEntity>

--- a/vim-canvas-demo-app-react/src/components/ui/button.tsx
+++ b/vim-canvas-demo-app-react/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors disabled:pointer-events-none disabled:opacity-50",
@@ -31,26 +31,26 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/vim-canvas-demo-app-react/src/components/ui/collapsibleEntity.tsx
+++ b/vim-canvas-demo-app-react/src/components/ui/collapsibleEntity.tsx
@@ -7,8 +7,7 @@ import {
 import { cn } from "@/lib/utils";
 import { CaretDownIcon } from "@radix-ui/react-icons";
 import cssFilterConverter from "css-filter-converter";
-import React, { PropsWithChildren, useState } from "react";
-import { EHR } from "vim-os-js-browser/types";
+import React, { PropsWithChildren, ReactNode, useState } from "react";
 import { Separator } from "./separator";
 
 const hexToFilter = (hex: string) => {
@@ -30,34 +29,48 @@ interface CollapsibleEntityProps {
     | "Patient"
     | "Encounter"
     | "Referral"
-    | "Order"
     | "Claim"
-    | `Order - ${EHR.OrderType}`;
+    | "Order"
+    | "Order created";
+  titleSuffix?: string;
   entityIconUrl: string;
   themeColor?: string;
+  badge?: "State" | "Event";
+  subtitle?: string;
+  rightAccessory?: ReactNode;
+  variant?: "default" | "dashed";
 }
 
 const DEFAULT_ICON_COLOR = "#04B39F";
 
 export function CollapsibleEntity({
   entityTitle,
+  titleSuffix,
   entityIconUrl,
   children,
   themeColor,
+  subtitle,
+  rightAccessory,
+  badge = "State",
+  variant = "default",
 }: React.PropsWithChildren<CollapsibleEntityProps>) {
   const [isOpen, setIsOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full mb-4">
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full mb-2">
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
           className={cn(
-            "w-[calc(100%-16px)] h-fit flex items-center hover:bg-[rgb(242,255,253)] bg-white justify-between rounded-lg p-4 m-4 mb-0 mx-2",
+            "w-[calc(100%-16px)] h-[50px] flex items-center hover:bg-[rgb(242,255,253)] bg-white justify-between p-2 m-2 mb-0 mx-2",
             {
               "rounded-b-none": isOpen,
-            }
+            },
+            variant === "dashed" &&
+              (isOpen
+                ? "border border-slate-500 border-dashed border-b-0"
+                : "border border-slate-500 border-dashed")
           )}
           style={{
             backgroundColor: isHovered
@@ -69,19 +82,40 @@ export function CollapsibleEntity({
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
         >
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
             <img
               src={entityIconUrl}
-              className="w-[20px] h-[20px]"
+              className="w-[25px] h-[25px]"
               style={{ filter: hexToFilter(themeColor ?? DEFAULT_ICON_COLOR) }}
             />
-            <h4 className="text-sm font-semibold">{entityTitle}</h4>
+            <div className="flex flex-col items-start">
+              <div className="flex items-baseline gap-1">
+                <h4 className="text-sm font-semibold">{entityTitle}</h4>
+                {titleSuffix && (
+                  <span className="text-xs text-slate-500 font-normal">
+                    {titleSuffix}
+                  </span>
+                )}
+              </div>
+              {subtitle && (
+                <span className="text-xs text-slate-500 font-normal">
+                  {subtitle}
+                </span>
+              )}
+            </div>
           </div>
-
-          <CaretDownIcon className="h-4 w-4" />
+          <div className="flex items-center gap-3">
+            <div className="flex items-center">
+              {rightAccessory}
+              <span className="text-[10px] px-1.5 rounded-full border border-slate-500 text-slate-500">
+                {badge}
+              </span>
+            </div>
+            <CaretDownIcon className="h-4 w-4" />
+          </div>
         </Button>
       </CollapsibleTrigger>
-      {isOpen && (
+      {isOpen && variant !== "dashed" && (
         <div className="w-[calc(100%-16px)] flex items-center bg-white justify-between pl-2 pr-4 mx-2">
           <Separator className="mb-1 mx-1" />
         </div>
@@ -91,10 +125,21 @@ export function CollapsibleEntity({
   );
 }
 
-export const CollapsibleEntityContent = ({ children }: PropsWithChildren) => {
+export const CollapsibleEntityContent = ({
+  children,
+  variant = "default",
+}: PropsWithChildren & { variant?: "default" | "dashed" }) => {
   return (
     <CollapsibleContent className="animateCollapsibleContent">
-      <div className="w-[calc(100%-16px)] flex items-center bg-white justify-between rounded-b-lg px-7 pt-1 pb-5 mx-2">
+      <div
+        className={cn(
+          "w-[calc(100%-16px)] flex items-center bg-white justify-between rounded-b-lg px-7 pt-1 pb-5 mx-2",
+          {
+            "border-x border-b border-slate-500 border-dashed":
+              variant === "dashed",
+          }
+        )}
+      >
         {children}
       </div>
     </CollapsibleContent>

--- a/vim-canvas-demo-app-react/src/components/ui/collapsibleEntity.tsx
+++ b/vim-canvas-demo-app-react/src/components/ui/collapsibleEntity.tsx
@@ -63,7 +63,7 @@ export function CollapsibleEntity({
         <Button
           variant="ghost"
           className={cn(
-            "w-[calc(100%-16px)] h-[50px] flex items-center hover:bg-[rgb(242,255,253)] bg-white justify-between p-2 m-2 mb-0 mx-2",
+            "w-[calc(100%-16px)] h-[50px] flex items-center hover:bg-[rgb(242,255,253)] bg-white justify-between p-2 m-3 mb-0 mx-2",
             {
               "rounded-b-none": isOpen,
             },

--- a/vim-canvas-demo-app-react/src/hooks/providers/OrdersContext.tsx
+++ b/vim-canvas-demo-app-react/src/hooks/providers/OrdersContext.tsx
@@ -1,14 +1,17 @@
-import { createContext, useEffect, useState } from "react";
+import { createContext, useCallback, useEffect, useState } from "react";
 import { EHR } from "vim-os-js-browser/types";
+import type { WorkflowEvent } from "@/types/workflowEvent";
 import { useVimOsContext } from "../useVimOsContext";
 import { useAppConfig } from "../useAppConfig";
 
 interface OrderContext {
-  orders: EHR.Order[] | undefined;
+  orders: EHR.Order[];
+  orderCreatedEvents: WorkflowEvent<EHR.Order>[];
 }
 
 export const VimOSOrdersContext = createContext<OrderContext>({
-  orders: undefined,
+  orders: [],
+  orderCreatedEvents: [],
 });
 
 export const VimOSOrdersProvider: React.FC<React.PropsWithChildren> = ({
@@ -16,23 +19,52 @@ export const VimOSOrdersProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
   const { updateNotification } = useAppConfig();
   const vimOS = useVimOsContext();
-  const [orders, setOrders] = useState<EHR.Order[] | undefined>(undefined);
+  const [orders, setOrders] = useState<EHR.Order[]>([]);
+  const [orderCreatedEvents, setOrderCreatedEvents] = useState<
+    WorkflowEvent<EHR.Order>[]
+  >([]);
 
   useEffect(() => {
     vimOS.ehr.subscribe("orders", (data) => {
-      setOrders(data);
+      setOrders(data ?? []);
       updateNotification("orders", data ? 1 : 0);
     });
 
     return () => {
-      vimOS.ehr.unsubscribe("orders", setOrders);
+      vimOS.ehr.unsubscribe("orders", (data) => setOrders(data ?? []));
     };
   }, [vimOS, updateNotification]);
+
+  const dismissOrderCreated = useCallback((id: string) => {
+    setOrderCreatedEvents((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = vimOS.ehr.workflowEvents.order.onOrderCreated(
+      (order: EHR.Order) => {
+        const orderCreatedEvent: WorkflowEvent<EHR.Order> = {
+          id: order?.identifiers?.ehrOrderId ?? "",
+          receivedAt: new Date(),
+          payload: order,
+          dismiss: () => dismissOrderCreated(orderCreatedEvent.id),
+        };
+        setOrderCreatedEvents((prev) => {
+          const exists = prev.some((e) => e.id === orderCreatedEvent.id);
+          const next = exists
+            ? prev
+            : [orderCreatedEvent, ...prev].slice(0, 10);
+          return next;
+        });
+      }
+    );
+    return () => unsubscribe();
+  }, [vimOS, dismissOrderCreated]);
 
   return (
     <VimOSOrdersContext.Provider
       value={{
         orders,
+        orderCreatedEvents,
       }}
     >
       {children}

--- a/vim-canvas-demo-app-react/src/types/workflowEvent.ts
+++ b/vim-canvas-demo-app-react/src/types/workflowEvent.ts
@@ -1,0 +1,6 @@
+export type WorkflowEvent<T> = {
+  id: string;
+  receivedAt: Date;
+  dismiss: () => void;
+  payload: T;
+};

--- a/vim-canvas-demo-app-react/src/utils/formatContentDate.ts
+++ b/vim-canvas-demo-app-react/src/utils/formatContentDate.ts
@@ -1,7 +1,10 @@
 import { format } from "date-fns";
 
-export const formatContentDate = (date: string | undefined) => {
+export const formatContentDate = (
+  date: string | Date | undefined,
+  options?: { format?: string }
+) => {
   if (!date) return;
 
-  return format(date, "MM/dd/yyyy");
+  return format(date, options?.format ?? "MM/dd/yyyy");
 };


### PR DESCRIPTION
## Summary
Adds a demo showcasing subscription to the new Workflow Events API and handling the Order Created event using VimOS SDK 2.0.12. 
Also aligns UI with the latest Figma spec by updating the default theme color and fixing card height to 50 px.

- **Docs**: [Changelog — 2.x.x (sdk) / 2.0.12 (npm) — Workflow Events, Order Created](https://docs.getvim.com/change-log/#_2-x-x-sdk-2-0-12-npm-september-7-2025)
- **Figma reference**: [Dev platform spec](https://www.figma.com/design/LJ0mAvfuOSLwppWPnWcWz3/Dev-platform?node-id=15892-29183&m=dev)

### What’s included
- Integrates subscription to `vimOS.ehr.workflowEvents` for the first event: Order Created.
- UI feedback in the demo app to surface received events (toast/log).
- Bumps SDK to 2.0.12 (npm) to enable the new event.
- Light code docs on wiring/handling the event.
- UI polish:
  - Updated default theme color to match Figma.
  - Standardized card height to 50 px to match Figma.

### Why
- Demonstrate reacting to discrete EHR user actions in real-time (starting with Order Created).
- Ensure visual consistency with design specs for theme and card size.

### Demo
![Sep-08-2025 00-19-53](https://github.com/user-attachments/assets/43779f5f-a371-4a63-a329-912abc3c921a)

### Figma Screenshot
<img width="317" height="661" alt="image" src="https://github.com/user-attachments/assets/f2610d6d-bd13-463d-a76e-f30772c728f9" />

### Notes
- Uses `vimOS.ehr.workflowEvents` introduced in 2.0.12.
- Additional workflow events can be added with similar wiring.