### PR TITLE
fix(useIdToken): catch getIdToken SDK errors instead of throwing

### DIFF
--- a/vim-canvas-demo-app-react/src/hooks/useIdToken.tsx
+++ b/vim-canvas-demo-app-react/src/hooks/useIdToken.tsx
@@ -12,7 +12,11 @@ export const useIdToken = () => {
   useEffect(() => {
     if (sessionContext) {
       (async () => {
-        setIdToken((await sessionContext.getIdToken())?.idToken);
+        try {
+          setIdToken((await sessionContext.getIdToken())?.idToken);
+        } catch {
+          // SDK error — leave idToken undefined
+        }
       })();
     }
   }, [sessionContext, setIdToken]);


### PR DESCRIPTION
Wrap the getIdToken call in a try/catch so SDK errors fail silently, leaving idToken undefined.